### PR TITLE
Add tasks.json for VSCode and implement MQTT v5 protocol support

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Run Pytest Tests",
+            "type": "shell",
+            "command": "uv run pytest tests",
+            "group": "test",
+            "problemMatcher": ["$python"]
+        }
+    ]
+}

--- a/src/mqtt_bridge/direct.py
+++ b/src/mqtt_bridge/direct.py
@@ -29,7 +29,7 @@ mqtt_subscriptions: Dict[str, List[str]] = {}
 received_messages: List[dict] = []
 
 
-def on_message_callback(client, userdata, message):
+def on_message_callback(client, userdata, message, properties=None):
     """Callback for when a message is received from MQTT broker."""
     try:
         payload = message.payload.decode("utf-8", errors="ignore")
@@ -78,7 +78,7 @@ def mqtt_connect(
     if not client_id:
         client_id = f"mcp-mqtt-direct-{connection_id}"
 
-    client = mqtt.Client(client_id=client_id, userdata={"connection_id": connection_id})
+    client = mqtt.Client(client_id=client_id, userdata={"connection_id": connection_id}, protocol=mqtt.MQTTv5)
 
     if username and password:
         client.username_pw_set(username, password)

--- a/src/mqtt_bridge/server.py
+++ b/src/mqtt_bridge/server.py
@@ -420,7 +420,7 @@ async def handle_list_tools() -> list[types.Tool]:
     ]
 
 
-def on_message_callback(client, userdata, message):
+def on_message_callback(client, userdata, message, properties=None):
     """Callback for when a message is received from MQTT broker."""
     try:
         payload = message.payload.decode("utf-8", errors="ignore")
@@ -463,7 +463,7 @@ async def handle_call_tool(
 
             # Create MQTT client
             client = mqtt.Client(
-                client_id=client_id, userdata={"connection_id": connection_id}
+                client_id=client_id, userdata={"connection_id": connection_id}, protocol=mqtt.MQTTv5
             )
 
             if username and password:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,52 @@
+"""
+Unit tests for mqtt_bridge core functionality.
+"""
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Import core modules
+from mqtt_bridge import direct, server, subscription_persistence
+
+class TestMQTTDirect(unittest.TestCase):
+    def test_mqtt_connect(self):
+        # Example: test connection logic
+        result = direct.mqtt_connect('test_id', 'test/topic', 0)
+        self.assertIsInstance(result, dict)
+
+    def test_mqtt_subscribe(self):
+        # Example: test subscribe logic
+        result = direct.mqtt_subscribe('test_id', 'test/topic', 1)
+        self.assertIsInstance(result, dict)
+
+    def test_mqtt_publish(self):
+        # Example: test publish logic
+        result = direct.mqtt_publish('test_id', 'test/topic', 'payload', 0)
+        self.assertIsInstance(result, dict)
+
+class TestMQTTServer(unittest.TestCase):
+    def test_on_message_callback(self):
+        # Example: test message callback
+        message = MagicMock()
+        message.topic = 'test/topic'
+        message.payload = b'test'
+        message.qos = 1
+        message.retain = False
+        with patch('mqtt_bridge.server.on_message_callback') as cb:
+            cb.return_value = None
+            cb(None, None, message)
+            cb.assert_called()
+
+class TestSubscriptionPersistence(unittest.TestCase):
+    def test_save_and_load_subscriptions(self):
+        subs = {'test_id': [('test/topic', 1)]}
+        result = subscription_persistence.save_subscriptions(subs)
+        self.assertTrue(result)
+        loaded = subscription_persistence.load_subscriptions()
+        self.assertIsInstance(loaded, dict)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Created a new tasks.json file for running Pytest tests in VSCode.
- Updated on_message_callback function to accept properties parameter.
- Modified MQTT client initialization to use MQTT v5 protocol in direct.py and server.py.
- Added unit tests for core functionality in test_core.py.