### PR TITLE
Use latest Paho MQTT callback API

### DIFF
--- a/src/mqtt_bridge/direct.py
+++ b/src/mqtt_bridge/direct.py
@@ -78,7 +78,12 @@ def mqtt_connect(
     if not client_id:
         client_id = f"mcp-mqtt-direct-{connection_id}"
 
-    client = mqtt.Client(client_id=client_id, userdata={"connection_id": connection_id}, protocol=mqtt.MQTTv5)
+    client = mqtt.Client(
+        callback_api_version=mqtt.CallbackAPIVersion.VERSION2,
+        client_id=client_id,
+        userdata={"connection_id": connection_id},
+        protocol=mqtt.MQTTv5,
+    )
 
     if username and password:
         client.username_pw_set(username, password)

--- a/src/mqtt_bridge/server.py
+++ b/src/mqtt_bridge/server.py
@@ -463,7 +463,10 @@ async def handle_call_tool(
 
             # Create MQTT client
             client = mqtt.Client(
-                client_id=client_id, userdata={"connection_id": connection_id}, protocol=mqtt.MQTTv5
+                callback_api_version=mqtt.CallbackAPIVersion.VERSION2,
+                client_id=client_id,
+                userdata={"connection_id": connection_id},
+                protocol=mqtt.MQTTv5,
             )
 
             if username and password:


### PR DESCRIPTION
## Summary
- use Paho MQTT callback API v2 when constructing clients

## Testing
- `uv run pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68a216795b788333aed1bc554f16aa3b